### PR TITLE
tests: add bhyveload mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ peda-session-*
 !.travis.yml
 
 tests/test-allocator
+tests/test-mock-bhyveload

--- a/tests/Kyuafile
+++ b/tests/Kyuafile
@@ -3,3 +3,4 @@ syntax(2)
 test_suite("libmultiboot")
 
 atf_test_program{name="test-allocator", }
+atf_test_program{name="test-mock-bhyveload", }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ LDFLAGS=-L/usr/local/lib
 LIBATF_C=/usr/local/lib/libatf-c.a
 
 .PHONY: all
-all: test-allocator
+all: test-allocator test-loader test-mock-bhyveload
 
 .PHONY: check
 check: all
@@ -12,7 +12,14 @@ check: all
 .PHONY: clean
 clean:
 	rm -f test-allocator.o
+	rm -f test-mock-bhyveload.o
+	rm -f mock/bhyveload.o
 	rm -f test-allocator
+
+test-mock-bhyveload: test-mock-bhyveload.o mock/bhyveload.o mock/compat-strlcat.o mock/compat-strlcpy.o
+	$(CC) ${LDFLAGS} ${CFLAGS} -o $@ $> ${LIBATF_C} ${LIBELF}
+
+test-loader: mock/bhyveload.o ../libmultiboot_p.a
 
 test-allocator: test-allocator.o ../libmultiboot_p.a
 	$(CC) ${LDFLAGS} ${CFLAGS} -o $@ $> ${LIBATF_C} ${LIBELF}

--- a/tests/mock/bhyveload.c
+++ b/tests/mock/bhyveload.c
@@ -1,0 +1,809 @@
+/*-
+ * Copyright (c) 2018 Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
+ * Copyright (c) 2011 NetApp, Inc.
+ * Copyright (c) 2011 Google, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Parts of this file are copied from usr.sbin/bhyveload/bhyveload.c
+ */
+
+#include <dirent.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/queue.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <userboot.h>
+#include <tests/mock/bhyveload.h>
+
+#define kiB (size_t) (1024)
+#define MiB (size_t) (1024 * 1024)
+#define GiB (size_t) (1024 * 1024 * 1024)
+
+#define BSP 0
+
+static char *host_base = ".";
+static void cb_exit(void *arg, int v);
+
+struct cb_file {
+    int cf_isdir;
+    size_t cf_size;
+    struct stat cf_stat;
+    union {
+        int fd;
+        DIR *dir;
+    } cf_u;
+};
+
+static void
+cb_putc(void *arg, int ch)
+{
+    cb_exit(arg, ENOSYS);
+}
+
+static int
+cb_getc(void *arg)
+{
+    cb_exit(arg, ENOSYS);
+}
+
+static int
+cb_poll(void *arg)
+{
+    cb_exit(arg, ENOSYS);
+}
+
+static int
+cb_open(void *arg, const char *filename, void **hp)
+{
+    struct cb_file *cf;
+    char path[PATH_MAX];
+
+    if (!host_base)
+        return (ENOENT);
+
+    strlcpy(path, host_base, PATH_MAX);
+    if (path[strlen(path) - 1] == '/')
+        path[strlen(path) - 1] = 0;
+    strlcat(path, filename, PATH_MAX);
+
+    cf = malloc(sizeof(struct cb_file));
+    if (stat(path, &cf->cf_stat) < 0) {
+        free(cf);
+        return (errno);
+    }
+
+    cf->cf_size = cf->cf_stat.st_size;
+    if (S_ISDIR(cf->cf_stat.st_mode)) {
+        cf->cf_isdir = 1;
+        cf->cf_u.dir = opendir(path);
+        if (!cf->cf_u.dir)
+            goto out;
+        *hp = cf;
+        return (0);
+    }
+    if (S_ISREG(cf->cf_stat.st_mode)) {
+        cf->cf_isdir = 0;
+        cf->cf_u.fd = open(path, O_RDONLY);
+        if (cf->cf_u.fd < 0)
+            goto out;
+        *hp = cf;
+        return (0);
+    }
+
+out:
+    free(cf);
+    return (EINVAL);
+}
+
+static int
+cb_close(void *arg, void *h)
+{
+    struct cb_file *cf = h;
+
+    if (cf->cf_isdir)
+        closedir(cf->cf_u.dir);
+    else
+        close(cf->cf_u.fd);
+    free(cf);
+
+    return (0);
+}
+
+static int
+cb_read(void *arg, void *h, void *buf, size_t size, size_t *resid)
+{
+    struct cb_file *cf = h;
+    ssize_t sz;
+
+    if (cf->cf_isdir)
+        return (EINVAL);
+    sz = read(cf->cf_u.fd, buf, size);
+    if (sz < 0)
+        return (EINVAL);
+    *resid = size - sz;
+    return (0);
+}
+
+static int
+cb_isdir(void *arg, void *h)
+{
+    struct cb_file *cf = h;
+
+    return (cf->cf_isdir);
+}
+
+static int
+cb_readdir(void *arg, void *h, uint32_t *fileno_return, uint8_t *type_return,
+       size_t *namelen_return, char *name)
+{
+    struct cb_file *cf = h;
+    struct dirent *dp;
+
+    if (!cf->cf_isdir)
+        return (EINVAL);
+
+    dp = readdir(cf->cf_u.dir);
+    if (!dp)
+        return (ENOENT);
+
+    /*
+     * Note: strlen(d_name) is in the range 0..255 and therefore less
+     * than PATH_MAX so we don't need to test before copying.
+     */
+    *fileno_return = dp->d_fileno;
+    *type_return = dp->d_type;
+    *namelen_return = strlen(dp->d_name);
+    memcpy(name, dp->d_name, strlen(dp->d_name));
+    name[strlen(dp->d_name)] = 0;
+
+    return (0);
+}
+
+static int
+cb_seek(void *arg, void *h, uint64_t offset, int whence)
+{
+    struct cb_file *cf = h;
+
+    if (cf->cf_isdir)
+        return (EINVAL);
+    if (lseek(cf->cf_u.fd, offset, whence) < 0)
+        return (errno);
+    return (0);
+}
+
+static int
+cb_stat(void *arg, void *h, int *mode, int *uid, int *gid, uint64_t *size)
+{
+    struct cb_file *cf = h;
+
+    *mode = cf->cf_stat.st_mode;
+    *uid = cf->cf_stat.st_uid;
+    *gid = cf->cf_stat.st_gid;
+    *size = cf->cf_stat.st_size;
+    return (0);
+}
+
+static void
+cb_exec(void* arg, uint64_t pc)
+{
+    /*
+     * Userboot's exec sets up registers for FreeBSD. This is not compatible
+     * with the state defined in the multiboot spec. Don't use cb_exec.
+     */
+    cb_exit(arg, ENOSYS);
+}
+
+static void
+cb_delay (void *arg, int usec)
+{
+    cb_exit(arg, ENOSYS);
+}
+
+static int
+cb_diskread(void *arg, int unit, uint64_t from, void *to, size_t size,
+        size_t *resid)
+{
+    cb_exit(arg, ENOSYS);
+}
+
+static int
+cb_diskioctl(void *arg, int unit, u_long cmd, void *data)
+{
+    cb_exit(arg, ENOSYS);
+}
+
+static size_t _lowmem = 0;
+static size_t _highmem = 0;
+void* highmem_buffer = NULL;
+void* lowmem_buffer = NULL;
+
+void
+setmem(size_t lowmem, size_t highmem) {
+    if (lowmem_buffer) free(lowmem_buffer);
+    if (highmem_buffer) free(highmem_buffer);
+
+    _lowmem = lowmem;
+    _highmem = highmem;
+
+    lowmem_buffer = calloc(1, lowmem);
+    highmem_buffer = calloc(1, highmem);
+}
+
+static void
+cb_getmem(void *arg, uint64_t *ret_lowmem, uint64_t *ret_highmem)
+{
+
+    *ret_lowmem = _lowmem;
+    *ret_highmem = _highmem;
+}
+
+struct env {
+    const char *str;    /* name=value */
+    SLIST_ENTRY(env) next;
+};
+
+static SLIST_HEAD(envhead, env) envhead;
+
+void
+addenv(const char *str)
+{
+    struct env *env;
+
+    env = malloc(sizeof(struct env));
+    env->str = str;
+    SLIST_INSERT_HEAD(&envhead, env, next);
+}
+
+static const char *
+cb_getenv(void *arg, int num)
+{
+    int i;
+    struct env *env;
+
+    i = 0;
+    SLIST_FOREACH(env, &envhead, next) {
+        if (i == num)
+            return (env->str);
+        i++;
+    }
+
+    return (NULL);
+}
+
+int exited = 0;
+int exit_reason = 0;
+
+static void
+cb_exit(void *arg, int v)
+{
+    exit_reason = v;
+    exited = 1;
+}
+
+/*
+ * Guest virtual machine i/o callbacks
+ */
+static int
+cb_copyin(void *arg, const void *from, uint64_t to, size_t size)
+{
+    void *ptr = NULL;
+    size_t offset = 0;
+    size_t seg_size = 0;
+
+    to &= 0x7fffffff;
+
+    if (to >= 4 * GiB) {
+        offset = 4 * GiB;
+        ptr = highmem_buffer + to - offset;
+        seg_size = _highmem;
+    }
+    else {
+        ptr = lowmem_buffer + to;
+        seg_size = _lowmem;
+    }
+
+    /* Don't overflow */
+    if (to - offset + size > seg_size)
+        return EFAULT;
+
+    /* Don't underflow */
+    if (to < offset)
+        return EFAULT;
+
+
+    memcpy(ptr, from, size);
+    return (0);
+}
+
+static int
+cb_copyout(void *arg, uint64_t from, void *to, size_t size)
+{
+    char *ptr;
+    size_t offset = 0;
+    size_t seg_size = 0;
+
+    from &= 0x7fffffff;
+
+    if (from >= 4 * GiB) {
+        offset = 4*GiB;
+        ptr = highmem_buffer + from - offset;
+        seg_size = _highmem;
+    }
+    else {
+        ptr = lowmem_buffer + from;
+        seg_size = _lowmem;
+    }
+
+    if (ptr == NULL)
+        return (EFAULT);
+
+    /* Don't overflow */
+    if (from - offset + size > seg_size)
+        return EFAULT;
+
+    /* Don't underflow */
+    if (from < offset)
+        return EFAULT;
+
+    memcpy(to, ptr, size);
+    return (0);
+}
+
+struct seg_desc {
+    uint64_t        base;
+    uint32_t        limit;
+    uint32_t        access;
+};
+
+
+/* Mock vm_{get,set}_desc from vmmapi. */
+static SLIST_HEAD(vm_seg_desc_head, vm_seg_desc) vm_seg_desc_head;
+
+struct vm_seg_desc { /* data or code segment */
+    int     cpuid;
+    int regnum;    /* enum vm_reg_name */
+    struct seg_desc desc;
+    SLIST_ENTRY(vm_seg_desc) next;
+};
+
+int
+vm_set_desc(struct vmctx *ctx, int vcpu, int reg,
+            uint64_t base, uint32_t limit, uint32_t access)
+{
+    struct vm_seg_desc *segdesc;
+
+    SLIST_FOREACH(segdesc, &vm_seg_desc_head, next) {
+        if (segdesc->cpuid != vcpu || segdesc->regnum != reg)
+            continue;
+
+        segdesc->desc.base = base;
+        segdesc->desc.limit = limit;
+        segdesc->desc.access = access;
+        return 0;
+    }
+
+    segdesc = calloc(1, sizeof(struct vm_seg_desc));
+    segdesc->cpuid = vcpu;
+    segdesc->regnum = reg;
+    segdesc->desc.base = base;
+    segdesc->desc.limit = limit;
+    segdesc->desc.access = access;
+    SLIST_INSERT_HEAD(&vm_seg_desc_head, segdesc, next);
+    return 0;
+}
+
+int
+vm_get_desc(struct vmctx *ctx, int vcpu, int reg,
+            uint64_t *base, uint32_t *limit, uint32_t *access)
+{
+    struct vm_seg_desc *segdesc;
+
+    SLIST_FOREACH(segdesc, &vm_seg_desc_head, next) {
+        if (segdesc->cpuid != vcpu || segdesc->regnum != reg)
+            continue;
+
+        *base = segdesc->desc.base;
+        *limit = segdesc->desc.limit;
+        *access = segdesc->desc.access;
+        return 0;
+    }
+
+    *base = 0;
+    *limit = 0;
+    *access = 0;
+    return 0;
+}
+
+/* Mock vm_{get,set}_register from vmmapi. */
+static SLIST_HEAD(vm_reg_head, vm_reg) vm_reg_head;
+
+struct vm_reg { /* data or code segment */
+    int    cpuid;
+    int regnum;    /* enum vm_reg_name */
+    uint64_t value;
+    SLIST_ENTRY(vm_reg) next;
+};
+
+int
+vm_set_register(struct vmctx *ctx, int vcpu, int reg, uint64_t val)
+{
+    struct vm_reg *_reg;
+    printf("set register %d = %lu\n", reg, val);
+
+    SLIST_FOREACH(_reg, &vm_reg_head, next) {
+        if (_reg->cpuid != vcpu || _reg->regnum != reg)
+            continue;
+
+        _reg->value = val;
+        return 0;
+    }
+
+    _reg = calloc(1, sizeof(struct vm_reg));
+    _reg->cpuid = vcpu;
+    _reg->regnum = reg;
+    _reg->value = val;
+    SLIST_INSERT_HEAD(&vm_reg_head, _reg, next);
+    return 0;
+}
+
+int
+vm_get_register(struct vmctx *ctx, int vcpu, int reg, uint64_t *retval)
+{
+    struct vm_reg *_reg;
+
+    SLIST_FOREACH(_reg, &vm_reg_head, next) {
+        if (_reg->cpuid != vcpu || _reg->regnum != reg)
+            continue;
+
+        *retval = _reg->value;
+        printf("get register %d = %lu\n", reg, *retval);
+        return 0;
+    }
+
+    return 0;
+}
+
+/*
+ * The following function is taken from vmmapi.c
+ * From Intel Vol 3a:
+ * Table 9-1. IA-32 Processor States Following Power-up293gg, Reset or INIT
+ */
+#define      CR0_NE  0x00000020
+int
+vcpu_reset(struct vmctx *vmctx, int vcpu)
+{
+    int error;
+    uint64_t rflags, rip, cr0, cr4, zero, desc_base, rdx;
+    uint32_t desc_access, desc_limit;
+    uint16_t sel;
+
+    zero = 0;
+
+    rflags = 0x2;
+    error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RFLAGS, rflags);
+    if (error)
+        goto done;
+
+    rip = 0xfff0;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RIP, rip)) != 0)
+        goto done;
+
+    cr0 = CR0_NE;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_CR0, cr0)) != 0)
+        goto done;
+
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_CR3, zero)) != 0)
+        goto done;
+    
+    cr4 = 0;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_CR4, cr4)) != 0)
+        goto done;
+
+    /*
+     * CS: present, r/w, accessed, 16-bit, byte granularity, usable
+     */
+    desc_base = 0xffff0000;
+    desc_limit = 0xffff;
+    desc_access = 0x0093;
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_CS,
+                desc_base, desc_limit, desc_access);
+    if (error)
+        goto done;
+
+    sel = 0xf000;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_CS, sel)) != 0)
+        goto done;
+
+    /*
+     * SS,DS,ES,FS,GS: present, r/w, accessed, 16-bit, byte granularity
+     */
+    desc_base = 0;
+    desc_limit = 0xffff;
+    desc_access = 0x0093;
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_SS,
+                desc_base, desc_limit, desc_access);
+    if (error)
+        goto done;
+
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_DS,
+                desc_base, desc_limit, desc_access);
+    if (error)
+        goto done;
+
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_ES,
+                desc_base, desc_limit, desc_access);
+    if (error)
+        goto done;
+
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_FS,
+                desc_base, desc_limit, desc_access);
+    if (error)
+        goto done;
+
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_GS,
+                desc_base, desc_limit, desc_access);
+    if (error)
+        goto done;
+
+    sel = 0;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_SS, sel)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_DS, sel)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_ES, sel)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_FS, sel)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_GS, sel)) != 0)
+        goto done;
+
+    /* General purpose registers */
+    rdx = 0xf00;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RAX, zero)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RBX, zero)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RCX, zero)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RDX, rdx)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RSI, zero)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RDI, zero)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RBP, zero)) != 0)
+        goto done;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_RSP, zero)) != 0)
+        goto done;
+
+    /* GDTR, IDTR */
+    desc_base = 0;
+    desc_limit = 0xffff;
+    desc_access = 0;
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_GDTR,
+                desc_base, desc_limit, desc_access);
+    if (error != 0)
+        goto done;
+
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_IDTR,
+                desc_base, desc_limit, desc_access);
+    if (error != 0)
+        goto done;
+
+    /* TR */
+    desc_base = 0;
+    desc_limit = 0xffff;
+    desc_access = 0x0000008b;
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_TR, 0, 0, desc_access);
+    if (error)
+        goto done;
+
+    sel = 0;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_TR, sel)) != 0)
+        goto done;
+
+    /* LDTR */
+    desc_base = 0;
+    desc_limit = 0xffff;
+    desc_access = 0x00000082;
+    error = vm_set_desc(vmctx, vcpu, VM_REG_GUEST_LDTR, desc_base,
+                desc_limit, desc_access);
+    if (error)
+        goto done;
+
+    sel = 0;
+    if ((error = vm_set_register(vmctx, vcpu, VM_REG_GUEST_LDTR, 0)) != 0)
+        goto done;
+
+    /* XXX cr2, debug registers */
+
+    error = 0;
+done:
+    return (error);
+}
+
+static int
+cb_vm_set_register(void *arg, int vcpu, int reg, uint64_t val)
+{
+    struct vmctx ctx;
+    return (vm_set_register(&ctx, vcpu, reg, val));
+}
+
+static int
+cb_vm_set_desc(void *arg, int vcpu, int reg, uint64_t base, u_int limit,
+    u_int access)
+{
+    struct vmctx ctx;
+    return (vm_set_desc(&ctx, vcpu, reg, base, limit, access));
+}
+
+static void
+cb_setreg(void *arg, int r, uint64_t v)
+{
+    int error;
+    enum vm_reg_name vmreg;
+    struct vmctx ctx;
+
+    vmreg = VM_REG_LAST;
+
+    switch (r) {
+    case 4:
+        vmreg = VM_REG_GUEST_RSP;
+        break;
+    default:
+        break;
+    }
+
+    if (vmreg == VM_REG_LAST) {
+        printf("test_setreg(%d): not implemented\n", r);
+        cb_exit(NULL, USERBOOT_EXIT_QUIT);
+    }
+
+    error = vm_set_register(&ctx, BSP, vmreg, v);
+    if (error) {
+        perror("vm_set_register");
+        cb_exit(NULL, USERBOOT_EXIT_QUIT);
+    }
+}
+
+static void
+cb_setmsr(void *arg, int r, uint64_t v)
+{
+    int error;
+    enum vm_reg_name vmreg;
+    struct vmctx ctx;
+
+    vmreg = VM_REG_LAST;
+
+    switch (r) {
+    case MSR_EFER:
+        vmreg = VM_REG_GUEST_EFER;
+        break;
+    default:
+        break;
+    }
+
+    if (vmreg == VM_REG_LAST) {
+        printf("test_setmsr(%d): not implemented\n", r);
+        cb_exit(NULL, USERBOOT_EXIT_QUIT);
+    }
+
+    error = vm_set_register(&ctx, BSP, vmreg, v);
+    if (error) {
+        perror("vm_set_msr");
+        cb_exit(NULL, USERBOOT_EXIT_QUIT);
+    }
+}
+
+static void
+cb_setcr(void *arg, int r, uint64_t v)
+{
+    struct vmctx ctx;
+    int error;
+    enum vm_reg_name vmreg;
+
+    vmreg = VM_REG_LAST;
+
+    switch (r) {
+    case 0:
+        vmreg = VM_REG_GUEST_CR0;
+        break;
+    case 3:
+        vmreg = VM_REG_GUEST_CR3;
+        break;
+    case 4:
+        vmreg = VM_REG_GUEST_CR4;
+        break;
+    default:
+        break;
+    }
+
+    if (vmreg == VM_REG_LAST) {
+        printf("test_setcr(%d): not implemented\n", r);
+        cb_exit(NULL, USERBOOT_EXIT_QUIT);
+    }
+
+    error = vm_set_register(&ctx, BSP, vmreg, v);
+    if (error) {
+        perror("vm_set_cr");
+        cb_exit(NULL, USERBOOT_EXIT_QUIT);
+    }
+}
+
+static void
+cb_setgdt(void *arg, uint64_t base, size_t size)
+{
+    struct vmctx ctx;
+    int error;
+
+    error = vm_set_desc(&ctx, BSP, VM_REG_GUEST_GDTR, base, size - 1, 0);
+    if (error != 0) {
+        perror("vm_set_desc(gdt)");
+        cb_exit(NULL, USERBOOT_EXIT_QUIT);
+    }
+}
+
+struct loader_callbacks callbacks = {
+    .getc = cb_getc,
+    .putc = cb_putc,
+    .poll = cb_poll,
+    
+    .open = cb_open,
+    .close = cb_close,
+    .isdir = cb_isdir,
+    .read = cb_read,
+    .readdir = cb_readdir,
+    .seek = cb_seek,
+    .stat = cb_stat,
+
+    .diskread = cb_diskread,
+    .diskioctl = cb_diskioctl,
+
+    .copyin = cb_copyin,
+    .copyout = cb_copyout,
+
+    .setreg = cb_setreg,
+    .setmsr = cb_setmsr,
+    .setcr = cb_setcr,
+    .setgdt = cb_setgdt,
+
+    .exec = cb_exec,
+    .delay = cb_delay,
+    .exit = cb_exit,
+    .getmem = cb_getmem,
+
+    .getenv = cb_getenv,
+
+    .vm_set_register = cb_vm_set_register,
+    .vm_set_desc = cb_vm_set_desc,
+};

--- a/tests/mock/bhyveload.h
+++ b/tests/mock/bhyveload.h
@@ -1,0 +1,72 @@
+#pragma once
+#include <sys/types.h>
+#include <userboot.h>
+
+extern int exited;
+extern int exit_reason;
+
+extern void* highmem_buffer;
+extern void* lowmem_buffer;
+
+extern struct loader_callbacks callbacks;
+
+void addenv(const char *str);
+void setmem(size_t lowmem, size_t highmem);
+
+
+/* vmmapi foo */
+#define MSR_EFER 0xc0000080
+
+/* opaque struct */
+struct vmctx {};
+
+enum vm_reg_name {
+        VM_REG_GUEST_RAX,
+        VM_REG_GUEST_RBX,
+        VM_REG_GUEST_RCX,
+        VM_REG_GUEST_RDX,
+        VM_REG_GUEST_RSI,
+        VM_REG_GUEST_RDI,
+        VM_REG_GUEST_RBP,
+        VM_REG_GUEST_R8,
+        VM_REG_GUEST_R9,
+        VM_REG_GUEST_R10,
+        VM_REG_GUEST_R11,
+        VM_REG_GUEST_R12,
+        VM_REG_GUEST_R13,
+        VM_REG_GUEST_R14,
+        VM_REG_GUEST_R15,
+        VM_REG_GUEST_CR0,
+        VM_REG_GUEST_CR3,
+        VM_REG_GUEST_CR4,
+        VM_REG_GUEST_DR7,
+        VM_REG_GUEST_RSP,
+        VM_REG_GUEST_RIP,
+        VM_REG_GUEST_RFLAGS,
+        VM_REG_GUEST_ES,
+        VM_REG_GUEST_CS,
+        VM_REG_GUEST_SS,
+        VM_REG_GUEST_DS,
+        VM_REG_GUEST_FS,
+        VM_REG_GUEST_GS,
+        VM_REG_GUEST_LDTR,
+        VM_REG_GUEST_TR,
+        VM_REG_GUEST_IDTR,
+        VM_REG_GUEST_GDTR,
+        VM_REG_GUEST_EFER,
+        VM_REG_GUEST_CR2,
+        VM_REG_GUEST_PDPTE0,
+        VM_REG_GUEST_PDPTE1,
+        VM_REG_GUEST_PDPTE2,
+        VM_REG_GUEST_PDPTE3,
+        VM_REG_GUEST_INTR_SHADOW,
+        VM_REG_LAST
+};
+
+int	vm_set_register(struct vmctx *ctx, int vcpu, int reg, uint64_t val);
+int	vm_get_register(struct vmctx *ctx, int vcpu, int reg, uint64_t *retval);
+int	vm_set_desc(struct vmctx *ctx, int vcpu, int reg,
+		    uint64_t base, uint32_t limit, uint32_t access);
+int	vm_get_desc(struct vmctx *ctx, int vcpu, int reg,
+		    uint64_t *base, uint32_t *limit, uint32_t *access);
+int	vcpu_reset(struct vmctx *ctx, int vcpu);

--- a/tests/mock/compat-strlcat.c
+++ b/tests/mock/compat-strlcat.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef HAVE_STRLCAT
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Appends src to string dst of size dsize (unlike strncat, dsize is the
+ * full size of dst, not space left).  At most dsize-1 characters
+ * will be copied.  Always NUL terminates (unless dsize <= strlen(dst)).
+ * Returns strlen(src) + MIN(dsize, strlen(initial dst)).
+ * If retval >= dsize, truncation occurred.
+ */
+size_t
+strlcat(char * __restrict dst, const char * __restrict src, size_t dsize)
+{
+	const char *odst = dst;
+	const char *osrc = src;
+	size_t n = dsize;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end. */
+	while (n-- != 0 && *dst != '\0')
+		dst++;
+	dlen = dst - odst;
+	n = dsize - dlen;
+
+	if (n-- == 0)
+		return(dlen + strlen(src));
+	while (*src != '\0') {
+		if (n != 0) {
+			*dst++ = *src;
+			n--;
+		}
+		src++;
+	}
+	*dst = '\0';
+
+	return(dlen + (src - osrc));	/* count does not include NUL */
+}
+#endif

--- a/tests/mock/compat-strlcpy.c
+++ b/tests/mock/compat-strlcpy.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#ifndef HAVE_STRLCPY
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+size_t
+strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize)
+{
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';		/* NUL-terminate dst */
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1);	/* count does not include NUL */
+}
+#endif

--- a/tests/test-mock-bhyveload.c
+++ b/tests/test-mock-bhyveload.c
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) 2018, Fabian Freyer <fabian.freyer@physik.tu-berlin.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <atf-c.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <tests/mock/bhyveload.h>
+
+#define kiB (size_t) (1024)
+#define MiB (size_t) (1024 * 1024)
+#define GiB (size_t) (1024 * 1024 * 1024)
+
+/* copyin into in the highmem is currently not supported by bhyveload. */
+#define TEST_HIGHMEM_ALLOCATION 0
+
+/* make sure getc and putc aren't defined as a macro */
+#ifdef getc
+#undef getc
+#endif
+
+#ifdef putc
+#undef putc
+#endif
+
+void* callbacks_arg = NULL;
+
+ATF_TC(mock_exit);
+ATF_TC_HEAD(mock_exit, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock bhyveload exit");
+}
+ATF_TC_BODY(mock_exit, tc)
+{
+    ATF_CHECK_EQ_MSG(exited, 0, "should not have exited yet.");
+    ATF_CHECK_EQ_MSG(exit_reason, 0, "exit_reason should not be set");
+    callbacks.exit(callbacks_arg, EINVAL);
+    ATF_CHECK_EQ_MSG(exited, 1, "should have exited.");
+    ATF_CHECK_EQ_MSG(exit_reason, EINVAL, "exit_reason should be EINVAL");
+}
+
+ATF_TC(mock_getenv);
+ATF_TC_HEAD(mock_getenv, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock bhyveload getenv");
+}
+ATF_TC_BODY(mock_getenv, tc)
+{
+    int i = 0;
+    const char* var;
+    addenv("smbios.bios.vendor=BHYVE");
+    addenv("boot_serial=1");
+
+    while ( (var = callbacks.getenv(callbacks_arg, i++)) ) {
+        switch(i) {
+        case 1:
+            ATF_CHECK_STREQ("boot_serial=1", var);
+            break;
+        case 2:
+            ATF_CHECK_STREQ("smbios.bios.vendor=BHYVE", var);
+            break;
+        default:
+            atf_tc_fail("expected only two environment variables, "
+                        "but at %ith now", i);
+        }
+    }
+}
+
+ATF_TC(mock_lowmemio);
+ATF_TC_HEAD(mock_lowmemio, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock bhyveload low memory I/O");
+}
+ATF_TC_BODY(mock_lowmemio, tc)
+{
+    int retv = 0;
+    size_t lowmem = 0, highmem = 0;
+
+    const char *testdata_lowmem = "this is the lowmem test data.";
+    char *outbuf = calloc(1, strlen(testdata_lowmem)+1);
+    uint64_t lowmem_test_address = 128 * kiB;
+
+    ATF_CHECK_EQ(0, highmem_buffer);
+    ATF_CHECK_EQ(0, lowmem_buffer);
+
+    setmem(256 * kiB, 4 * kiB);
+
+    ATF_CHECK_EQ(0, highmem_buffer == 0);
+    ATF_CHECK_EQ(0, lowmem_buffer == 0);
+
+    callbacks.getmem(callbacks_arg, &lowmem, &highmem);
+
+    ATF_CHECK_EQ(256 * kiB, lowmem);
+    ATF_CHECK_EQ(4 * kiB, highmem);
+
+    retv = callbacks.copyin(callbacks_arg, testdata_lowmem,
+                            lowmem_test_address, strlen(testdata_lowmem)+1);
+
+    ATF_CHECK_EQ_MSG(0, retv, "lowmem copyin failed");
+
+    ATF_CHECK_STREQ(testdata_lowmem, lowmem_buffer + 128 * kiB);
+
+    retv = callbacks.copyout(callbacks_arg, lowmem_test_address, outbuf,
+                                strlen(testdata_lowmem)+1);
+
+    ATF_CHECK_STREQ(testdata_lowmem, outbuf);
+
+    free(outbuf);
+}
+
+#if TEST_HIGHMEM_ALLOCATION
+ATF_TC(mock_highmemio);
+ATF_TC_HEAD(mock_highmemio, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock bhyveload high memory I/O");
+}
+ATF_TC_BODY(mock_highmemio, tc)
+{
+    int retv = 0;
+    size_t lowmem = 0, highmem = 0;
+
+    const char *testdata_highmem = "this is the highmem test data.";
+    uint64_t highmem_test_address = 4 * GiB + 128 * kiB;
+
+    ATF_CHECK_EQ(0, highmem_buffer);
+    ATF_CHECK_EQ(0, lowmem_buffer);
+
+    setmem(4 * kiB, 256 * kiB);
+
+    ATF_CHECK_EQ(0, highmem_buffer == 0);
+    ATF_CHECK_EQ(0, lowmem_buffer == 0);
+
+    callbacks.getmem(callbacks_arg, &lowmem, &highmem);
+
+    ATF_CHECK_EQ(4 * kiB, lowmem);
+    ATF_CHECK_EQ(256 * kiB, highmem);
+
+    retv = callbacks.copyin(callbacks_arg, testdata_highmem,
+                            highmem_test_address, strlen(testdata_highmem)+1);
+
+    ATF_CHECK_EQ_MSG(0, retv, "highmem copyin failed");
+
+    ATF_CHECK_STREQ(testdata_highmem, highmem_buffer + 128 * kiB);
+}
+#endif
+
+static void
+mkfile(const char* filename, const char* data, size_t size)
+{
+    FILE* f = fopen(filename, "w");
+    fwrite(data, size, 1, f);
+    fclose(f);
+}
+
+ATF_TC(mock_hostfileio);
+ATF_TC_HEAD(mock_hostfileio, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock bhyveload host file I/O");
+}
+ATF_TC_BODY(mock_hostfileio, tc)
+{
+    void *filehandle;
+    void *dirhandle;
+    int retv = 0;
+    int mode = 0, uid = 0, gid = 0;
+    uint32_t fileno = 0;
+    uint8_t type = 0;
+    size_t namelen = 0;
+    char *name = malloc(256);
+
+    uint64_t size = 0, resid = 0;
+    char* buffer = NULL;
+
+    const char *testdata = "this is a test file.";
+    mkfile("testfile", testdata, strlen(testdata));
+    mkdir("testdirectory", 0700);
+    mkfile("testdirectory/aaa", "", 0);
+    mkfile("testdirectory/bbbb", "", 0);
+    mkfile("testdirectory/ccccc", "", 0);
+
+    retv = callbacks.open(callbacks_arg, "/testfile", &filehandle);
+    ATF_CHECK_EQ_MSG(0, retv, "open failed");
+
+    retv = callbacks.isdir(callbacks_arg, filehandle);
+    ATF_CHECK_EQ_MSG(0, retv, "isdir failed");
+
+    retv = callbacks.stat(callbacks_arg, filehandle, &mode, &uid, &gid, &size);
+    ATF_CHECK_EQ_MSG(0, retv, "stat failed");
+    ATF_CHECK_EQ(strlen(testdata), size);
+
+    buffer = calloc(1, size);
+    if (!buffer)
+            atf_tc_fail("could not allocate memory");
+
+    retv = callbacks.read(callbacks_arg, filehandle, buffer, size, &resid);
+    ATF_CHECK_EQ_MSG(0, retv, "read failed");
+    ATF_CHECK_STREQ(testdata, buffer);
+
+    if (buffer)
+        free(buffer);
+
+    buffer = calloc(1, size);
+    if (!buffer)
+            atf_tc_fail("could not allocate memory");
+
+    retv = callbacks.seek(callbacks_arg, filehandle, 5, SEEK_SET);
+    ATF_CHECK_EQ_MSG(0, retv, "seek failed");
+
+    retv = callbacks.read(callbacks_arg, filehandle, buffer, size, &resid);
+    ATF_CHECK_EQ_MSG(0, retv, "read failed");
+    ATF_CHECK_STREQ(testdata+5, buffer);
+
+    if (buffer)
+        free(buffer);
+
+    retv = callbacks.close(callbacks_arg, filehandle);
+    ATF_CHECK_EQ_MSG(0, retv, "close failed");
+
+    retv = callbacks.open(callbacks_arg, "/testdirectory", &dirhandle);
+    ATF_CHECK_EQ_MSG(0, retv, "open failed");
+
+    retv = callbacks.isdir(callbacks_arg, dirhandle);
+    ATF_CHECK_EQ_MSG(1, retv, "isdir failed");
+
+    retv = callbacks.seek(callbacks_arg, dirhandle, 5, SEEK_SET);
+    ATF_CHECK_EQ(EINVAL, retv);
+
+    retv = callbacks.read(callbacks_arg, dirhandle, NULL, size, &resid);
+    ATF_CHECK_EQ_MSG(EINVAL, retv, "read failed");
+
+    while (!(retv = callbacks.readdir(callbacks_arg, dirhandle, &fileno,
+                                    &type, &namelen, name)))
+    {
+        switch(namelen) {
+            case 1:
+                ATF_CHECK_STREQ(".", name);
+                break;
+            case 2:
+                ATF_CHECK_STREQ("..", name);
+                break;
+            case 3:
+                ATF_CHECK_STREQ("aaa", name);
+                break;
+            case 4:
+                ATF_CHECK_STREQ("bbbb", name);
+                break;
+            case 5:
+                ATF_CHECK_STREQ("ccccc", name);
+                break;
+            default:
+                atf_tc_fail("extra file in test directory");
+        }
+    }
+
+    retv = callbacks.close(callbacks_arg, filehandle);
+    ATF_CHECK_EQ_MSG(0, retv, "close failed");
+}
+
+#define TESTCASE_NOTIMPLEMENTED(fcn, args...) \
+    ATF_TC(mock_ ## fcn); \
+    ATF_TC_HEAD(mock_ ## fcn, tc) \
+    { atf_tc_set_md_var(tc, "descr", "Test that " #fcn "isn't implemented"); } \
+    ATF_TC_BODY(mock_ ## fcn, tc) { \
+        (&callbacks)->fcn(callbacks_arg , ##args); \
+        ATF_CHECK_EQ_MSG(exited, 1, "should have exited."); \
+        ATF_CHECK_EQ_MSG(exit_reason, ENOSYS, "exit_reason should be ENOSYS"); \
+    }
+
+ATF_TC(mock_vmmapi);
+ATF_TC_HEAD(mock_vmmapi, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock VMMAPI functions");
+}
+ATF_TC_BODY(mock_vmmapi, tc)
+{
+    struct vmctx ctx;
+    uint32_t access, limit;
+    uint64_t rip, base;
+    vcpu_reset(&ctx, 0);
+
+    vm_get_register(&ctx, 0, VM_REG_GUEST_RIP, &rip);
+    ATF_CHECK_EQ_MSG(0xfff0, rip,
+                        "rip not initialized correctly after cpu reset");
+
+    callbacks.vm_set_register(callbacks_arg, 0, VM_REG_GUEST_RIP, 0xDEADBEEF);
+    rip = 0;
+    vm_get_register(&ctx, 0, VM_REG_GUEST_RIP, &rip);
+
+    ATF_CHECK_EQ_MSG(0xdeadbeef, rip,
+                        "setting rip via vm_set_register failed");
+
+    vm_get_desc(&ctx, 0, VM_REG_GUEST_CS, &base, &limit, &access);
+    ATF_CHECK_EQ(0xffff0000, base);
+    ATF_CHECK_EQ(0xffff, limit);
+    ATF_CHECK_EQ(0x0093, access);
+
+    base = limit = access = 0;
+    callbacks.vm_set_desc(callbacks_arg, 0, VM_REG_GUEST_CS,
+                            0xaaaa0000, 0xcccc, 0x92);
+
+    vm_get_desc(&ctx, 0, VM_REG_GUEST_CS, &base, &limit, &access);
+    ATF_CHECK_EQ(0xaaaa0000, base);
+    ATF_CHECK_EQ(0xcccc, limit);
+    ATF_CHECK_EQ(0x0092, access);
+}
+
+ATF_TC(mock_setreg);
+ATF_TC_HEAD(mock_setreg, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock setreg callback");
+}
+ATF_TC_BODY(mock_setreg, tc)
+{
+    struct vmctx ctx;
+    int error = 0;
+    uint64_t actual;
+
+    /* Can only set RSP */
+    callbacks.setreg(callbacks_arg, 4, 0xdeadbeef);
+    ATF_CHECK_EQ_MSG(0, exited, "setreg failed for RSP");
+
+    error = vm_get_register(&ctx, 0, VM_REG_GUEST_RSP, &actual);
+    ATF_CHECK_EQ_MSG(0, error, "vm_get_register failed");
+    ATF_CHECK_EQ_MSG(0xdeadbeef, actual, "wrong RSP value");
+
+    callbacks.setreg(callbacks_arg, 5, 0xdeadc0de);
+    ATF_CHECK_EQ_MSG(1, exited, "setreg succeeded");
+}
+
+ATF_TC(mock_setmsr);
+ATF_TC_HEAD(mock_setmsr, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock setmsr callback");
+}
+ATF_TC_BODY(mock_setmsr, tc)
+{
+    struct vmctx ctx;
+    int error = 0;
+    uint64_t actual;
+
+    /* Can only set EFER */
+    callbacks.setmsr(callbacks_arg, MSR_EFER, 0xdeadbeef);
+    ATF_CHECK_EQ_MSG(0, exited, "setmsr failed for EFER");
+
+    error = vm_get_register(&ctx, 0, VM_REG_GUEST_EFER, &actual);
+    ATF_CHECK_EQ_MSG(0, error, "vm_get_register failed");
+    ATF_CHECK_EQ_MSG(0xdeadbeef, actual, "wrong EFER value");
+
+    callbacks.setmsr(callbacks_arg, 0, 0xdeadc0d3);
+    ATF_CHECK_EQ_MSG(1, exited, "setmsr succeeded");
+}
+
+ATF_TC(mock_setcr);
+ATF_TC_HEAD(mock_setcr, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock setcr callback");
+}
+ATF_TC_BODY(mock_setcr, tc)
+{
+    struct vmctx ctx;
+    int error = 0;
+    uint64_t actual;
+
+    /* Can only set CR0, CR3, CR4 */
+    callbacks.setcr(callbacks_arg, 0, 0xdeadbeef);
+    ATF_CHECK_EQ_MSG(0, exited, "setcr failed for CR0");
+
+    error = vm_get_register(&ctx, 0, VM_REG_GUEST_CR0, &actual);
+    ATF_CHECK_EQ_MSG(0, error, "vm_get_register failed");
+    ATF_CHECK_EQ_MSG(0xdeadbeef, actual, "wrong CR0 value");
+
+    callbacks.setcr(callbacks_arg, 3, 0xdeadbeef);
+    ATF_CHECK_EQ_MSG(0, exited, "setcr failed for CR3");
+
+    error = vm_get_register(&ctx, 0, VM_REG_GUEST_CR3, &actual);
+    ATF_CHECK_EQ_MSG(0, error, "vm_get_register failed");
+    ATF_CHECK_EQ_MSG(0xdeadbeef, actual, "wrong CR3 value");
+
+    callbacks.setcr(callbacks_arg, 4, 0xdeadbeef);
+    ATF_CHECK_EQ_MSG(0, exited, "setcr failed for CR4");
+
+    error = vm_get_register(&ctx, 0, VM_REG_GUEST_CR4, &actual);
+    ATF_CHECK_EQ_MSG(0, error, "vm_get_register failed");
+    ATF_CHECK_EQ_MSG(0xdeadbeef, actual, "wrong CR4 value");
+
+    callbacks.setcr(callbacks_arg, 1, 0xdeadc0d3);
+    ATF_CHECK_EQ_MSG(1, exited, "setcr succeeded");
+}
+
+ATF_TC(mock_setgdt);
+ATF_TC_HEAD(mock_setgdt, tc)
+{
+    atf_tc_set_md_var(tc, "descr", "Test mock setgdt callback");
+}
+ATF_TC_BODY(mock_setgdt, tc)
+{
+    struct vmctx ctx;
+    int error = 0;
+    uint64_t actual_base;
+    uint32_t actual_size;
+    uint32_t actual_access;
+
+    callbacks.setgdt(callbacks_arg, 0xdeadbeef, 0x1337);
+    ATF_CHECK_EQ_MSG(0, exited, "setgdt failed");
+
+    error = vm_get_desc(&ctx, 0, VM_REG_GUEST_GDTR,
+                        &actual_base, &actual_size, &actual_access);
+    ATF_CHECK_EQ_MSG(0, error, "vm_get_register failed");
+    ATF_CHECK_EQ_MSG(0xdeadbeef, actual_base, "wrong base");
+    ATF_CHECK_EQ_MSG(0x1336, actual_size, "wrong size");
+    ATF_CHECK_EQ_MSG(0, actual_access, "wrong access");
+}
+
+TESTCASE_NOTIMPLEMENTED(getc);
+TESTCASE_NOTIMPLEMENTED(putc, 'a');
+TESTCASE_NOTIMPLEMENTED(poll);
+TESTCASE_NOTIMPLEMENTED(diskread, 0, 0, NULL, 0, NULL);
+TESTCASE_NOTIMPLEMENTED(diskioctl, 0, 0, NULL);
+TESTCASE_NOTIMPLEMENTED(exec, 0);
+TESTCASE_NOTIMPLEMENTED(delay, 0);
+
+ATF_TP_ADD_TCS(tp)
+{
+    ATF_TP_ADD_TC(tp, mock_exit);
+    ATF_TP_ADD_TC(tp, mock_getenv);
+    ATF_TP_ADD_TC(tp, mock_lowmemio);
+#if TEST_HIGHMEM_ALLOCATION
+    ATF_TP_ADD_TC(tp, mock_highmemio);
+#endif
+    ATF_TP_ADD_TC(tp, mock_hostfileio);
+    ATF_TP_ADD_TC(tp, mock_getc);
+    ATF_TP_ADD_TC(tp, mock_putc);
+    ATF_TP_ADD_TC(tp, mock_poll);
+    ATF_TP_ADD_TC(tp, mock_diskread);
+    ATF_TP_ADD_TC(tp, mock_diskioctl);
+    ATF_TP_ADD_TC(tp, mock_exec);
+    ATF_TP_ADD_TC(tp, mock_delay);
+    ATF_TP_ADD_TC(tp, mock_vmmapi);
+    ATF_TP_ADD_TC(tp, mock_setreg);
+    ATF_TP_ADD_TC(tp, mock_setmsr);
+    ATF_TP_ADD_TC(tp, mock_setcr);
+    ATF_TP_ADD_TC(tp, mock_setgdt);
+
+    return atf_no_error();
+}

--- a/userboot.h
+++ b/userboot.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <sys/types.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 /*

--- a/userboot.h
+++ b/userboot.h
@@ -26,6 +26,8 @@
  * $FreeBSD: head/sys/boot/userboot/userboot.h 296099 2016-02-26 16:00:16Z marcel $
  */
 
+#pragma once
+
 #include <sys/types.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
Contributes to #1 

- [x] Mock out the following callbacks:
  * [x] getc: not implemented
  * [x] putc: not implemented
  * [x] poll: not implemented
  * [x] open: copy from bhyveload
  * [x] close: copy from bhyveload
  * [x] isdir: copy from bhyveload
  * [x] read: copy from bhyveload
  * [x] readdir: copy from bhyveload
  * [x] seek: copy from bhyveload
  * [x] stat: copy from bhyveload
  * [x] diskread: not implemented
  * [x] diskioctl: not implemented
  * [x] copyin:  mock out
  * [x] copyout:  mock out
  * [x] setreg:  mock out
  * [x] setmsr:  mock out
  * [x] setcr:  mock out
  * [x] setgdt:  mock out
  * [x] exec:  not implemented
  * [x] delay:  not implemented
  * [x] exit: mock out
  * [x] getmem: mock out
  * [x] getenv: copy from bhyveload
  * [x] vm_set_register:  mock out
  * [x] vm_set_desc:  mock out
- [x] write tests that the mock callbacks work as expected:
  * [x] getc
  * [x] putc
  * [x] poll
  * [x] open
  * [x] close
  * [x] isdir
  * [x] read
  * [x] readdir
  * [x] seek
  * [x] stat
  * [x] diskread
  * [x] diskioctl
  * [x] copyin
  * [x] copyout
  * [x] setreg
  * [x] setmsr
  * [x] setcr
  * [x] setgdt
  * [x] exec
  * [x] delay
  * [x] exit
  * [x] getmem
  * [x] getenv
  * [x] vm_set_register
  * [x] vm_set_desc